### PR TITLE
Add --saveworld argument to stop command

### DIFF
--- a/arkshortcut.sh
+++ b/arkshortcut.sh
@@ -16,7 +16,7 @@ case "$cmd" in
 		arkmanager start
 		;;
 	"stop")
-		arkmanager stop
+		arkmanager stop --saveworld
 		;;
 	"status")
 		arkmanager status


### PR DESCRIPTION
Noticed at times the server didn't always save when stopped, usually when the container is stopped via Portainer.